### PR TITLE
Interface fix (#44)

### DIFF
--- a/hippynn/interfaces/ase_interface/calculator.py
+++ b/hippynn/interfaces/ase_interface/calculator.py
@@ -4,7 +4,6 @@ import numpy as np
 import warnings
 import torch
 
-from ase.calculators import interface
 from ase.calculators.calculator import compare_atoms, PropertyNotImplementedError, Calculator # Calculator is required to allow HIPNN to be used with ASE Mixing Calculators
 
 from hippynn.graphs import find_relatives, find_unique_relative, get_subgraph, copy_subgraph, replace_node, GraphModule

--- a/hippynn/interfaces/lammps_interface/mliap_interface.py
+++ b/hippynn/interfaces/lammps_interface/mliap_interface.py
@@ -41,7 +41,7 @@ class MLIAPInterface(MLIAPUnified):
         # Build the calculator
         self.rcutfac, self.species_set, self.graph = setup_LAMMPS_graph(energy_node)
         self.nparams = sum(p.nelement() for p in self.graph.parameters())
-        self.graph.to(torch.float64)
+        self.graph.to(torch.float32)
 
     def compute_gradients(self, data):
         pass
@@ -62,7 +62,7 @@ class MLIAPInterface(MLIAPUnified):
         z_vals = self.species_set[elems+1]
         pair_i = self.as_tensor(data.pair_i).type(torch.int64)
         pair_j = self.as_tensor(data.pair_j).type(torch.int64)
-        rij = self.as_tensor(data.rij).type(torch.float64)
+        rij = self.as_tensor(data.rij).type(torch.float32)
         nlocal = self.as_tensor(data.nlistatoms) 
            
         # note your sign for rij might need to be +1 or -1, depending on how your implementation works

--- a/hippynn/layers/targets.py
+++ b/hippynn/layers/targets.py
@@ -67,7 +67,7 @@ class HEnergy(torch.nn.Module):
             total_hier = torch.zeros_like(total_energies)
             mol_hier = torch.zeros_like(total_energies)
             total_atom_hier = torch.zeros_like(total_atomen)
-            batch_hier = torch.zeros(1,dtype=total_energies.dtype,device=total_energies.dtype)
+            batch_hier = torch.zeros(1,dtype=total_energies.dtype,device=total_energies.device)
 
         return total_energies, total_atomen, partial_sums, total_hier, total_atom_hier, mol_hier, batch_hier
 


### PR DESCRIPTION
* Added database options to remove outlier data

    def remove_high_property(self,key,perAtom,species_key=None,cut=None,std_factor=10):
        """
        This function removes outlier data from the dataset
        Must be called before splitting
        "key": the property key in the dataset to check for high values
        "perAtom": True if the property is defined per atom in axis 1, otherwise property is treated as full system
        "std_factor": systems with values larger than this multiplier time the standard deviation of all data will be reomved. None to skip this step
        "cut_factor": systems with values larger than this number are reomved. None to skip this step. This step is done first.
        """

* unnecessary index type constraint for vectors (#31) (#32)

This was causing lammps interfaces not to build correctly.

* Removed ase interface reference from calculator

This causes errors with later versions of ase

* changed model to float 32

* Fixed devide in targes.py(70)

* Fixes for lammps and ase interface

lammps: reduce float64 to float32 for speed
ase: remove reference to calculator

* Reverted merge mistakes with database.py

---------